### PR TITLE
Implement theme chooser and theme management for Memorize app

### DIFF
--- a/Memorize/CardView.swift
+++ b/Memorize/CardView.swift
@@ -56,7 +56,7 @@ struct CardView: View {
 
 extension Animation {
     static func spin(duration: TimeInterval) -> Animation {
-        .linear(duration: 1).repeatForever(autoreverses: false)
+        .linear(duration: 1)
     }
 }
 

--- a/Memorize/EmojiMemoryGame.swift
+++ b/Memorize/EmojiMemoryGame.swift
@@ -6,46 +6,22 @@
 //
 
 import Foundation
-import SwiftUI
 
 class EmojiMemoryGame: ObservableObject {
     typealias Card = MemoryGame<String>.Card
-    private static var theme = "default" {
-        willSet {
-            switch newValue {
-            case "vehicle":
-                emojis = vehicleEmojis
-            case "sport":
-                emojis = sportEmojis
-            case "animal":
-                emojis = animalEmojis
-            case "food":
-                emojis = foodEmojis
-            case "nature":
-                emojis = natureEmojis
-            case "face":
-                emojis = facesEmojis
-            default:
-                emojis = defaultEmojis
-            }
-        }
+    
+    @Published private var model: MemoryGame<String>
+    private var theme: Theme
+    
+    init(theme: Theme) {
+        model = EmojiMemoryGame.createMemoryGame(theme: theme)
+        self.theme = theme
     }
     
-    private var themes = ["default", "vehicle", "sport", "animal", "food", "nature", "face"]
-    
-    private static var emojis = defaultEmojis
-    
-    
-    static let vehicleEmojis = ["🚗", "🚕", "🚙", "🚌", "🚎", "🏎️", "🚓", "🚑", "🚒", "🚜"]
-    static let sportEmojis = ["⚽️", "🏀", "🏈", "⚾️", "🎾", "🏐", "🏉", "🎱", "🏓", "🏸"]
-    static let animalEmojis = ["🐶", "🐱", "🐭", "🐹", "🐰", "🦊", "🐻", "🐼", "🐨", "🐯"]
-    static let foodEmojis = ["🍎", "🍌", "🍇", "🍓", "🍒", "🍉", "🍍", "🍑", "🥝", "🍆"]
-    static let natureEmojis = ["🌲", "🌳", "🌴", "🌵", "🌿", "☘️", "🌻", "🌼", "🌷", "🍂"]
-    static let facesEmojis = ["😀", "😂", "😍", "😎", "😡", "😭", "🥳", "😱", "😴", "🤯"]
-    private static let defaultEmojis = ["💕", "💠", "🪿", "🐣", "🦀", "🍉", "🦋", "🌪️", "🍒","🐝"]
-    
-    private static func createMemoryGame() -> MemoryGame<String> {
-        return MemoryGame(numberOfPairs: 2) { pairIndex in
+    private static func createMemoryGame(theme: Theme) -> MemoryGame<String> {
+        var emojis = theme.emojis.uniqued.map(String.init)
+        let numberOfPairs = min(theme.count, 8)
+        return MemoryGame(numberOfPairs: numberOfPairs) { pairIndex in
             if let randomIndex = emojis.indices.randomElement() {
                 return emojis.remove(at: randomIndex)
             } else {
@@ -54,7 +30,6 @@ class EmojiMemoryGame: ObservableObject {
         }
     }
     
-    @Published private var model = createMemoryGame()
     
     var score: Int {
         return model.score
@@ -62,6 +37,14 @@ class EmojiMemoryGame: ObservableObject {
     
     var cards: Array<Card> {
         return model.cards
+    }
+    
+    var themeColor: RGBA {
+        theme.color
+    }
+    
+    var themeName: String {
+        theme.name
     }
     
     // MARK: Intents
@@ -74,34 +57,7 @@ class EmojiMemoryGame: ObservableObject {
         print(card.content, card.id)
     }
     
-    func getTheme() -> String {
-        return EmojiMemoryGame.theme.capitalized
-    }
-    
-    func themeColor() -> Color {
-        switch EmojiMemoryGame.theme {
-        case "vehicle":
-            return .red
-        case "sport":
-            return .blue
-        case "animal":
-            return .brown
-        case "food":
-            return .orange
-        case "nature":
-            return .green
-        case "face":
-            return .yellow
-        default:
-            return .gray
-        }
-    }
-    
     func newGame() {
-        if let randomTheme = themes.randomElement() {
-            EmojiMemoryGame.theme = randomTheme
-        }
-        model = EmojiMemoryGame.createMemoryGame()
-        shuffle()
+        model = EmojiMemoryGame.createMemoryGame(theme: theme)
     }
 }

--- a/Memorize/EmojiMemoryGameView.swift
+++ b/Memorize/EmojiMemoryGameView.swift
@@ -19,28 +19,21 @@ struct EmojiMemoryGameView: View {
     
     var body: some View {
         VStack {
-            HStack {
-                theme
-                Spacer()
-                newGame
-            }
-            cards.foregroundColor(viewModel.themeColor())
+            cards.foregroundColor(Color(rgba: viewModel.themeColor))
             HStack {
                 score
                 Spacer()
-                deck.foregroundStyle(viewModel.themeColor())
+//                deck.foregroundStyle(Color(rgba: viewModel.themeColor))
                 Spacer()
-                shuffle
+//                shuffle
             }
             .font(.title)
         }
         .padding()
-    }
-    
-    private var theme: some View {
-        Text(viewModel.getTheme())
-            .font(.title)
-            .foregroundStyle(viewModel.themeColor())
+        .navigationTitle(viewModel.themeName)
+        .toolbar {
+            newGame
+        }
     }
     
     private var score: some View {
@@ -48,13 +41,13 @@ struct EmojiMemoryGameView: View {
             .animation(nil)
     }
     
-    private var shuffle: some View {
-        Button("Shuffle") {
-            withAnimation {
-                viewModel.shuffle()
-            }
-        }
-    }
+//    private var shuffle: some View {
+//        Button("Shuffle") {
+//            withAnimation {
+//                viewModel.shuffle()
+//            }
+//        }
+//    }
     
     private var newGame: some View {
         Button("New Game") {
@@ -64,9 +57,9 @@ struct EmojiMemoryGameView: View {
     
     private var cards: some View {
         AspectVGrid(viewModel.cards, aspectRatio: aspectRatio) { card in
-            if isDealt(card) {
+//            if isDealt(card) {
                 CardView(card)
-                    .matchedGeometryEffect(id: card.id, in: dealingNameSpace)
+//                    .matchedGeometryEffect(id: card.id, in: dealingNameSpace)
                     .transition(.asymmetric(insertion: .identity, removal: .identity))
                     .padding(spacing)
                     .overlay(FlyingNumber(number: scoreChange(causedBy: card)))
@@ -74,44 +67,44 @@ struct EmojiMemoryGameView: View {
                     .onTapGesture {
                         choose(card)
                     }
-            }
+//            }
         }
     }
     
-    @State private var dealt = Set<Card.ID>()
+//    @State private var dealt = Set<Card.ID>()
+//    
+//    private func isDealt(_ card: Card) -> Bool {
+//        dealt.contains(card.id)
+//    }
+//    private var undealtCards: [Card] {
+//        viewModel.cards.filter { !isDealt($0) }
+//    }
+//    
+//    @Namespace private var dealingNameSpace
+//    
+//    private var deck: some View {
+//        ZStack {
+//            ForEach(undealtCards) { card in
+//                CardView(card)
+//                    .matchedGeometryEffect(id: card.id, in: dealingNameSpace)
+//                    .transition(.asymmetric(insertion: .identity, removal: .identity))
+//            }
+//        }
+//        .frame(width: deckWidth, height: deckWidth / aspectRatio)
+//        .onTapGesture {
+//            deal()
+//        }
+//    }
     
-    private func isDealt(_ card: Card) -> Bool {
-        dealt.contains(card.id)
-    }
-    private var undealtCards: [Card] {
-        viewModel.cards.filter { !isDealt($0) }
-    }
-    
-    @Namespace private var dealingNameSpace
-    
-    private var deck: some View {
-        ZStack {
-            ForEach(undealtCards) { card in
-                CardView(card)
-                    .matchedGeometryEffect(id: card.id, in: dealingNameSpace)
-                    .transition(.asymmetric(insertion: .identity, removal: .identity))
-            }
-        }
-        .frame(width: deckWidth, height: deckWidth / aspectRatio)
-        .onTapGesture {
-            deal()
-        }
-    }
-    
-    private func deal() {
-        var delay: TimeInterval = 0
-        for card in viewModel.cards {
-            withAnimation(dealAnimation.delay(delay)) {
-                _ = dealt.insert(card.id)
-            }
-            delay += dealInterval
-        }
-    }
+//    private func deal() {
+//        var delay: TimeInterval = 0
+//        for card in viewModel.cards {
+//            withAnimation(dealAnimation.delay(delay)) {
+//                _ = dealt.insert(card.id)
+//            }
+//            delay += dealInterval
+//        }
+//    }
     
     private func choose(_ card: Card) {
         withAnimation {
@@ -130,6 +123,10 @@ struct EmojiMemoryGameView: View {
     }
 }
 
+
+
 #Preview {
-    EmojiMemoryGameView(viewModel: EmojiMemoryGame())
+    var theme = Theme.builtins.first!
+    var emojiMemoryGame = EmojiMemoryGame(theme: theme)
+    EmojiMemoryGameView(viewModel: emojiMemoryGame)
 }

--- a/Memorize/Extensions.swift
+++ b/Memorize/Extensions.swift
@@ -1,0 +1,49 @@
+//
+//  Extensions.swift
+//  Memorize
+//
+//  Created by ali cihan on 7.11.2024.
+//
+
+import Foundation
+
+extension String {
+    mutating func remove(_ ch: Character) {
+        removeAll(where: { $0 == ch })
+    }
+}
+
+extension String {
+    // removes any duplicate Characters
+    // preserves the order of the Characters
+    var uniqued: String {
+        // not super efficient
+        // would only want to use it on small(ish) strings
+        // and we wouldn't want to call it in a tight loop or something
+        reduce(into: "") { sofar, element in
+            if !sofar.contains(element) {
+                sofar.append(element)
+            }
+        }
+    }
+}
+
+extension Character {
+    var isEmoji: Bool {
+        // Swift does not have a way to ask if a Character isEmoji
+        // but it does let us check to see if our component scalars isEmoji
+        // unfortunately unicode allows certain scalars (like 1)
+        // to be modified by another scalar to become emoji (e.g. 1️⃣)
+        // so the scalar "1" will report isEmoji = true
+        // so we can't just check to see if the first scalar isEmoji
+        // the quick and dirty here is to see if the scalar is at least the first true emoji we know of
+        // (the start of the "miscellaneous items" section)
+        // or check to see if this is a multiple scalar unicode sequence
+        // (e.g. a 1 with a unicode modifier to force it to be presented as emoji 1️⃣)
+        if let firstScalar = unicodeScalars.first, firstScalar.properties.isEmoji {
+            return (firstScalar.value >= 0x238d || unicodeScalars.count > 1)
+        } else {
+            return false
+        }
+    }
+}

--- a/Memorize/MemorizeApp.swift
+++ b/Memorize/MemorizeApp.swift
@@ -9,11 +9,14 @@ import SwiftUI
 
 @main
 struct MemorizeApp: App {
-    @StateObject var game = EmojiMemoryGame()
+//    @StateObject var game = EmojiMemoryGame()
+    @StateObject var themeStore = ThemeStore(name: "Main")
     
     var body: some Scene {
         WindowGroup {
-            EmojiMemoryGameView(viewModel: game)
+//            EmojiMemoryGameView(viewModel: game)
+            ThemeChooser()
+                .environmentObject(themeStore)
         }
     }
 }

--- a/Memorize/MemoryGame.swift
+++ b/Memorize/MemoryGame.swift
@@ -19,11 +19,10 @@ struct MemoryGame<CardContent> where CardContent: Equatable {
         for pairIndex in 0..<max(2, numberOfPairs) {
             let content = cardContentFactory(pairIndex)
             let id = UUID().uuidString
-//            cards.append(Card(content: content, id: "\(pairIndex+1)a"))
             cards.append(Card(content: content, id: "\(id)a"))
-//            cards.append(Card(content: content, id: "\(pairIndex+1)b"))
             cards.append(Card(content: content, id: "\(id)b"))
         }
+        cards.shuffle()
     }
     
     var indexOfTheOneAndOnlyFaceUpCard: Int? {

--- a/Memorize/RGBA.swift
+++ b/Memorize/RGBA.swift
@@ -1,0 +1,30 @@
+//
+//  RGBA.swift
+//  Memorize
+//
+//  Created by ali cihan on 9.11.2024.
+//
+
+import SwiftUI
+
+struct RGBA: Codable, Equatable, Hashable {
+    let red: Double
+    let green: Double
+    let blue: Double
+    let alpha: Double
+}
+extension Color {
+    init(rgba: RGBA) {
+        self.init(.sRGB, red: rgba.red, green: rgba.green, blue: rgba.blue, opacity: rgba.alpha)
+    }
+}
+extension RGBA {
+    init(color: Color) {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        UIColor(color).getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        self.init(red: Double(red), green: Double(green), blue: Double(blue), alpha: Double(alpha))
+    }
+}

--- a/Memorize/Theme.swift
+++ b/Memorize/Theme.swift
@@ -1,0 +1,36 @@
+//
+//  Theme.swift
+//  Memorize
+//
+//  Created by ali cihan on 6.11.2024.
+//
+
+import Foundation
+
+
+struct Theme: Identifiable, Codable {
+    var name: String
+    var emojis: String
+    var id = UUID()
+    var color: RGBA
+    var count = 2
+    var removedEmojis : String = ""
+    
+    static var newThemeTemplate: Theme {
+        Theme(name: "", emojis: "", color: RGBA(red: 1/255, green: 1/255, blue: 1/255, alpha: 1))
+    }
+    
+    static var builtins: [Theme] {
+        [
+            Theme(name: "Vehicles", emojis: "🚙🚗🚘🚕🚖🏎🚚🛻🚛🚐🚓🚔🚑🚒🚀✈️🛫🛬🛩🚁🛸🚲🏍🛶⛵️🚤🛥🛳⛴🚢🚂🚝🚅🚆🚊🚉🚇🛺🚜", color: RGBA(red: 1/255, green: 1/255, blue: 75/255, alpha: 1)),
+            Theme(name: "Sports", emojis: "🏈⚾️🏀⚽️🎾🏐🥏🏓⛳️🥅🥌🏂⛷🎳", color: RGBA(red: 200/255, green: 1/255, blue: 75/255, alpha: 1)),
+            Theme(name: "Music", emojis: "🎼🎤🎹🪘🥁🎺🪗🪕🎻", color: RGBA(red: 200/255, green: 1/255, blue: 75/255, alpha: 1)),
+            Theme(name: "Animals", emojis: "🐥🐣🐂🐄🐎🐖🐏🐑🦙🐐🐓🐁🐀🐒🦆🦅🦉🦇🐢🐍🦎🦖🦕🐅🐆🦓🦍🦧🦣🐘🦛🦏🐪🐫🦒🦘🦬🐃🦙🐐🦌🐕🐩🦮🐈🦤🦢🦩🕊🦝🦨🦡🦫🦦🦥🐿🦔", color: RGBA(red: 200/255, green: 1/255, blue: 75/255, alpha: 1)),
+            Theme(name: "Animal Faces", emojis: "🐵🙈🙊🙉🐶🐱🐭🐹🐰🦊🐻🐼🐻‍❄️🐨🐯🦁🐮🐷🐸🐲", color: RGBA(red: 200/255, green: 1/255, blue: 75/255, alpha: 1)),
+            Theme(name: "Flora", emojis: "🌲🌴🌿☘️🍀🍁🍄🌾💐🌷🌹🥀🌺🌸🌼🌻", color: RGBA(red: 200/255, green: 1/255, blue: 75/255, alpha: 1)),
+            Theme(name: "Weather", emojis: "☀️🌤⛅️🌥☁️🌦🌧⛈🌩🌨❄️💨☔️💧💦🌊☂️🌫🌪", color: RGBA(red: 200/255, green: 1/255, blue: 75/255, alpha: 1)),
+            Theme(name: "COVID", emojis: "💉🦠😷🤧🤒", color: RGBA(red: 200/255, green: 1/255, blue: 75/255, alpha: 1)),
+            Theme(name: "Faces", emojis: "😀😃😄😁😆😅😂🤣🥲☺️😊😇🙂🙃😉😌😍🥰😘😗😙😚😋😛😝😜🤪🤨🧐🤓😎🥸🤩🥳😏😞😔😟😕🙁☹️😣😖😫😩🥺😢😭😤😠😡🤯😳🥶😥😓🤗🤔🤭🤫🤥😬🙄😯😧🥱😴🤮😷🤧🤒🤠", color: RGBA(red: 200/255, green: 1/255, blue: 75/255, alpha: 1))
+        ]
+    }
+}

--- a/Memorize/ThemeChooser.swift
+++ b/Memorize/ThemeChooser.swift
@@ -1,0 +1,48 @@
+//
+//  ThemeChooser.swift
+//  Memorize
+//
+//  Created by ali cihan on 6.11.2024.
+//
+
+import SwiftUI
+
+struct ThemeChooser: View {
+    @EnvironmentObject var store: ThemeStore
+    @State private var showThemeEditor: Bool = false
+    
+    var body: some View {
+        NavigationStack {
+            ZStack(alignment: .bottomTrailing) {
+                ThemeList()
+                addNewThemeButton
+            }
+        }
+        .sheet(isPresented: $showThemeEditor) {
+            ThemeEditor(theme: $store.themes[store.cursorIndex])
+        }
+    }
+    
+    private var addNewThemeButton: some View {
+        Button {
+            addNewTheme()
+            showThemeEditor = true
+        } label: {
+            Circle().frame(width: 50)
+                .padding()
+                .overlay {
+                    Image(systemName: "plus")
+                        .foregroundStyle(.white)
+                }
+        }
+    }
+    
+    private func addNewTheme() {
+        store.addNewTheme()
+    }
+}
+
+#Preview {
+    ThemeChooser()
+        .environmentObject(ThemeStore(name: "Preview"))
+}

--- a/Memorize/ThemeEditor.swift
+++ b/Memorize/ThemeEditor.swift
@@ -1,0 +1,142 @@
+//
+//  ThemeEditor.swift
+//  Memorize
+//
+//  Created by ali cihan on 6.11.2024.
+//
+
+import SwiftUI
+
+struct ThemeEditor: View {
+    @Binding var theme: Theme
+    
+    @State private var selectedColor: Color = .white
+    private let emojiFont = Font.system(size: 40)
+    
+    @State private var emojisToAdd: String = ""
+    
+    enum Focused {
+        case name, emoji
+    }
+    
+    @FocusState private var focused: Focused?
+    
+    private var gameEmojiCount: Int {
+        max(theme.emojis.uniqued.count, 2)
+    }
+    
+    var body: some View {
+        Form {
+            nameSection
+            colorSection
+            gameEmojiPairs
+            addEmojis
+            removeEmojis
+            reAddEmojis
+        }
+        .onAppear {
+            selectedColor = Color(rgba: theme.color)
+        }
+        .onDisappear {
+            theme.color = RGBA(color: selectedColor)
+        }
+    }
+    
+    private var nameSection: some View {
+        Section(header: Text("Name")) {
+            TextField("Name", text: $theme.name)
+                .focused($focused, equals: .name)
+        }
+    }
+    
+    private var colorSection: some View {
+        Section(header: Text("Color")) {
+            HStack {
+                Text("Color: ")
+                ColorPicker(selection: $selectedColor) { }
+            }
+        }
+    }
+    
+    private var gameEmojiPairs: some View {
+        Section("Game Emoji Pair"){
+            Stepper("Count: \(theme.count)", value: $theme.count, in: 2...gameEmojiCount, step: 1)
+        }
+    }
+    
+    private var addEmojis: some View {
+        Section(header: Text("Emojis")) {
+        TextField("Add emojis here", text: $emojisToAdd)
+            .focused($focused, equals: .emoji)
+            .onChange(of: emojisToAdd) {
+                theme.emojis = (emojisToAdd + theme.emojis)
+                    .filter { $0.isEmoji }
+                    .uniqued
+            }
+        }
+    }
+    
+    private var removeEmojis: some View {
+        VStack(alignment: .trailing) {
+            Text("Tap to Remove Emojis").font(.caption).foregroundStyle(.gray)
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 40))]) {
+                ForEach(theme.emojis.uniqued.map(String.init), id: \.self) { emoji in
+                    Text(emoji)
+                        .onTapGesture {
+                            removeEmoji(emoji: emoji)
+                        }
+                }
+            }
+        }
+        .font(emojiFont)
+    }
+    
+    @ViewBuilder
+    private var reAddEmojis: some View {
+        if !theme.removedEmojis.isEmpty {
+            Section {
+                VStack(alignment: .trailing) {
+                    Text("Tap to recover Emojis").font(.caption).foregroundStyle(.gray)
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 40))]) {
+                        ForEach(theme.removedEmojis.uniqued.map(String.init), id: \.self) { emoji in
+                            Text(emoji)
+                                .onTapGesture {
+                                    recoverEmoji(emoji: emoji)
+                                }
+                        }
+                    }
+                }
+                .font(emojiFont)
+            }
+        }
+    }
+    
+    private func removeEmoji(emoji: String) {
+        withAnimation {
+            theme.emojis.remove(emoji.first!)
+            emojisToAdd.remove(emoji.first!)
+            theme.removedEmojis = (theme.removedEmojis + emoji).filter { $0.isEmoji }
+                .uniqued
+        }
+    }
+    
+    private func recoverEmoji(emoji: String) {
+        withAnimation {
+            theme.emojis = (theme.emojis + emoji)
+                .filter { $0.isEmoji }
+                .uniqued
+            theme.removedEmojis.remove(emoji.first!)
+        }
+    }
+}
+
+#Preview {
+    ThemeEditor_Preview()
+}
+
+struct ThemeEditor_Preview: View {
+    @State private var theme = ThemeStore(name: "Preview").themes.first!
+    var body: some View {
+        ThemeEditor(theme: $theme)
+    }
+}

--- a/Memorize/ThemeList.swift
+++ b/Memorize/ThemeList.swift
@@ -1,0 +1,83 @@
+//
+//  ThemeList.swift
+//  Memorize
+//
+//  Created by ali cihan on 9.11.2024.
+//
+
+import SwiftUI
+
+struct ThemeList: View {
+    @EnvironmentObject var store: ThemeStore
+    
+    @State private var showThemeEditor: Bool = false
+    
+    @State private var emojiMemoryGames: [String : EmojiMemoryGame] = [:]
+    
+    var body: some View {
+        List {
+            ForEach(store.themes) { theme in
+                rowView(theme: theme)
+                    .swipeActions(edge: .leading) {
+                        editButton(withThemeId: theme.id)
+                    }
+            }
+            .onDelete { indexSet in
+                withAnimation {
+                    store.themes.remove(atOffsets: indexSet)
+                }
+            }
+            .onMove { indexSet, newOffset in
+                store.themes.move(fromOffsets: indexSet, toOffset: newOffset)
+            }
+        }
+        .navigationDestination(for: Theme.ID.self) { themeId in
+            if let index = store.themes.firstIndex(where: { $0.id == themeId }) {
+                if let emojiMemoryGame = emojiMemoryGames[themeId.uuidString] {
+                    EmojiMemoryGameView(viewModel: emojiMemoryGame)
+                } else {
+                    EmojiMemoryGameView(viewModel: createViewModel(withThemeId: themeId, index: index))
+                }
+            }
+        }
+        .sheet(isPresented: $showThemeEditor) {
+            ThemeEditor(theme: $store.themes[store.cursorIndex])
+        }
+    }
+    
+    private func createViewModel(withThemeId id: Theme.ID, index: Int) -> EmojiMemoryGame {
+        let viewModel = EmojiMemoryGame(theme: store.themes[index])
+        emojiMemoryGames[id.uuidString] = viewModel
+        return viewModel
+    }
+    
+    private func rowView(theme: Theme) -> some View {
+        return NavigationLink(value: theme.id) {
+            VStack(alignment: .leading) {
+                Text(theme.name)
+                HStack {
+                    Text("Color: ")
+                    Rectangle().frame(width: 25, height: 25).foregroundStyle(Color(rgba: theme.color))
+                    Spacer()
+                    Text("Emoji count: \(theme.count)")
+                }
+                Text(theme.emojis)
+                    .lineLimit(1)
+            }
+        }
+    }
+    
+    private func editButton(withThemeId id: Theme.ID) -> some View {
+        Button {
+            store.setCursorIndex(withThemeId: id)
+            showThemeEditor = true
+        } label: {
+            Label("Edit", systemImage: "plus.circle")
+        }
+    }
+}
+
+#Preview {
+    ThemeList()
+        .environmentObject(ThemeStore(name: "Preview"))
+}

--- a/Memorize/ThemeStore.swift
+++ b/Memorize/ThemeStore.swift
@@ -1,0 +1,64 @@
+//
+//  ThemeStore.swift
+//  Memorize
+//
+//  Created by ali cihan on 6.11.2024.
+//
+
+import Foundation
+
+extension UserDefaults {
+    func themes(forKey key: String) -> [Theme] {
+        if let jsonData = data(forKey: key),
+           let decodedThemes = try? JSONDecoder().decode([Theme].self, from: jsonData) {
+            return decodedThemes
+        } else {
+            return []
+        }
+    }
+    
+    func set(_ themes: [Theme], forKey key: String) {
+        let data = try? JSONEncoder().encode(themes)
+        set(data, forKey: key)
+    }
+}
+
+class ThemeStore: ObservableObject {
+    let name: String
+    
+    var id: String { name }
+    
+    private var userDefaultsKey: String { "ThemeStore:" + name }
+    
+    var themes: [Theme] {
+        get {
+            UserDefaults.standard.themes(forKey: userDefaultsKey)
+        }
+        set {
+            if !newValue.isEmpty {
+                UserDefaults.standard.set(newValue, forKey: userDefaultsKey)
+                objectWillChange.send()
+            }
+        }
+    }
+    
+    init(name: String) {
+        self.name = name
+        if themes.isEmpty {
+            themes = Theme.builtins
+        }
+    }
+    
+    @Published var cursorIndex = 0
+    
+    func setCursorIndex(withThemeId id: Theme.ID) {
+        if let index = themes.firstIndex(where: { $0.id == id }) {
+            cursorIndex = index
+        }
+    }
+    
+    func addNewTheme() {
+        themes.insert(Theme.newThemeTemplate, at: 0)
+        cursorIndex = 0
+    }
+}


### PR DESCRIPTION
Added a theme chooser UI as the main view, displaying themes in a list with theme-specific info: name, color, card count, and emoji sample.
Refactored EmojiMemoryGame ViewModel to use a theme variable to configure the game; removed theme initialization and storage logic.
Enabled navigation from the theme chooser list to start a game with the selected theme, preserving existing game functionality like score and new game.
Implemented the ability to add, delete, and edit themes:
Added a button to create new themes, supporting persistence with UserDefaults.
Enabled swipe-to-delete functionality in the theme list.
Added modal theme editing UI using a Form with controls to modify theme properties (name, emojis, card count, and color selection via RGBA struct).
Added persistence for themes to retain changes across app launches.
Retained "removed" emoji state for themes, allowing users to restore emojis if desired.